### PR TITLE
Fix the race condition while requesting certificate from CA

### DIFF
--- a/hdfs2gcs-terraform/certs_auth/nifi.tf
+++ b/hdfs2gcs-terraform/certs_auth/nifi.tf
@@ -117,8 +117,8 @@ resource "google_compute_instance" "nifi" {
         echo "waiting for CA server"
         sleep 1m
         
-        su nifi -c 'export PATH=$PATH:/usr/lib/jvm/jdk/bin && cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
         until  ls ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json; do
+        su nifi -c 'export PATH=$PATH:/usr/lib/jvm/jdk/bin && cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
         sleep 1
         done
         KEYSTORE_PASSWORD=`cat ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json | grep -o '"keyStorePassword" : "[^"]*' | grep -o '[^"]*$' `

--- a/hdfs2gcs-terraform/external_ip_enabled/nifi.tf
+++ b/hdfs2gcs-terraform/external_ip_enabled/nifi.tf
@@ -102,8 +102,8 @@ resource "google_compute_instance" "nifi" {
           echo "waiting for CA server"
           sleep 1m
           
-          su nifi -c 'cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
           until  ls ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json; do
+          su nifi -c 'cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
           sleep 1
           done
           KEYSTORE_PASSWORD=`cat ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json | grep -o '"keyStorePassword" : "[^"]*' | grep -o '[^"]*$' `

--- a/hdfs2gcs-terraform/single_user_auth/nifi.tf
+++ b/hdfs2gcs-terraform/single_user_auth/nifi.tf
@@ -118,8 +118,8 @@ resource "google_compute_instance" "nifi" {
           echo "waiting for CA server"
           sleep 1m
           
-          su nifi -c 'export PATH=$PATH:/usr/lib/jvm/jdk/bin && cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
           until  ls ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json; do
+          su nifi -c 'export PATH=$PATH:/usr/lib/jvm/jdk/bin && cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
           sleep 1
           done
           KEYSTORE_PASSWORD=`cat ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json | grep -o '"keyStorePassword" : "[^"]*' | grep -o '[^"]*$' `


### PR DESCRIPTION
This mitigates the race condition when nifi node requests the certificate from CA while CA is still bootstrapping.